### PR TITLE
issue 13, PALIGNR missing imm8 operand3

### DIFF
--- a/x86reference.xml
+++ b/x86reference.xml
@@ -9892,6 +9892,7 @@
 	  <mnem>PALIGNR</mnem>
 	  <dst><a>P</a><t>q</t></dst>
 	  <src><a>Q</a><t>q</t></src>
+	  <src><a>I</a><t>b</t></src>
 	</syntax>
         <instr_ext>ssse3</instr_ext>  
 	<grp1>simdint</grp1>
@@ -9905,6 +9906,7 @@
 	  <mnem>PALIGNR</mnem>
 	  <dst><a>V</a><t>dq</t></dst>
 	  <src><a>W</a><t>dq</t></src>
+	  <src><a>I</a><t>b</t></src>
 	</syntax>
         <instr_ext>ssse3</instr_ext>  
 	<grp1>simdint</grp1>


### PR DESCRIPTION
patch for #13 PALIGNR missing imm8 as operand 3. 